### PR TITLE
Update imports .py

### DIFF
--- a/xtract_features/imports/imports.py
+++ b/xtract_features/imports/imports.py
@@ -15,7 +15,7 @@ from numpy import array
 from os.path import dirname, join
 from tqdm import tqdm
 from PIL import Image
-from scipy.misc import imresize
+# from scipy.misc import imresize
 from scipy.signal import convolve2d
 from skimage.segmentation import slic, mark_boundaries, clear_border
 from skimage.measure import label, regionprops


### PR DESCRIPTION
imresize is deprecated from the latest versions of scipy package (>= 1.2.0). It is suggested to use numpy.array(Image.fromarray(arr).resize())  instead.